### PR TITLE
Change beauvine default_message in Hiera

### DIFF
--- a/data/domain/beauvine.vm.yaml
+++ b/data/domain/beauvine.vm.yaml
@@ -1,5 +1,5 @@
 ---
-profile::pasture::app::default_message: "Welcome to Beauvine!"
+profile::pasture::app::default_message: "Hello control repository!"
 profile::base::dev_users::users:
   - title: 'bessie'
     comment: 'Bessie Johnson'


### PR DESCRIPTION
Change the default_message value for the beauvine domain to "Hello
control repository!" to demonstrate the code management workflow with a
control repository.