### PR TITLE
Add Puppetfile with puppetlabs-postgresql module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,0 +1,2 @@
+mod "puppetlabs/postgresql", '5.12.1'
+


### PR DESCRIPTION
The Pasture module depends on the `puppetlabs-postgresql` module for
the database-backed version of the application. Add a Puppetfile
to include this module and its dependencies.